### PR TITLE
Add netrc-check script for easy access. Update to go 1.9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.8
+FROM golang:1.9
+
+ENV SCRIPTS /docker-startup/scripts/
+
+COPY scripts /docker-startup/
 
 RUN go get -u github.com/kardianos/govendor \
 	&& go get golang.org/x/tools/cmd/goimports \

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ Go docker image with preloaded toolset
 
 This image builds in the following tools along with go:
 
-* govendor
+* govendor - https://github.com/kardianos/govendor
 * golint
 * goimports
+* go dep - https://github.com/golang/dep
+
+Use the netrc-check.sh to load your .netrc file into ~/ for go dep.
+
+To use .netrc with github personal access tokens, add a .netrc file with
+the following contents in your working directory:
+```
+machine github.com
+    login GITHUB_TOKEN
+```

--- a/scripts/netrc-check.sh
+++ b/scripts/netrc-check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f ".netrc" ]; then
+    cp .netrc ~/
+fi
+
+$@


### PR DESCRIPTION
Hi All,

go dep uses .netrc for github credentials since it disables password prompts: https://github.com/golang/dep/issues/1177 I have added a netrc-check script for ease of use since it must be copied specifically into the ~/ directory.

Please review @excelWithBusiness/developers